### PR TITLE
Fix browser name

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -25,6 +25,6 @@ module.exports = function(config){
             'test/*.js'
         ],
         autoWatch: true,
-        browsers: ['firefox']
+        browsers: ['Firefox']
     });
 };


### PR DESCRIPTION
Karma needs a browser definition that is case-sensitive.

This PR fixes:

``` console
npm test

> angular-slider@0.3.2 test /venturocket-angular-slider
> karma start --single-run --no-auto-watch

WARN [karma]: Port 9876 in use
INFO [karma]: Karma v0.10.10 server started at http://localhost:9877/
WARN [launcher]: Can not load "firefox", it is not registered!
  Perhaps you are missing some plugin?
```
