### PR TITLE
Use correct semver range to avoid resolution errors.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,8 +18,8 @@
 		"*.html"
     ],
     "dependencies": {
-        "angular": "~1.2.*",
-		"angular-touch": "~1.2.*"
+        "angular": "~1.2",
+        "angular-touch": "~1.2"
     },
     "devDependencies": {
         "angular-mocks": "*",


### PR DESCRIPTION
Prior to this change, this package would resolve its dependencies as the latest version of `angular` and `angular-touch` causing bower resolution errors when installing it, rather than being content with any `1.2` release, which I think is what you meant.

More information here: https://www.npmjs.org/package/semver#ranges
