### PR TITLE
Properly align the text of the main 'bubble' when sliding it all the way to the right.

### DIFF
--- a/src/angular-slider.js
+++ b/src/angular-slider.js
@@ -924,8 +924,8 @@ angular.module('vr.directives.slider', ['ngTouch']).directive('slider',
 
                                     // set the low knob's and bubble's new positions
                                     offset(refs.minPtr, offsetFromPercent(stretchedLowPercent));
-                                    offset(refs.lowBub,
-                                        offsetFromPercent(percentFromOffset(offsetLeft(refs.minPtr) - halfWidth(refs.lowBub) + pointerHalfWidth)));
+	                                offset(refs.lowBub, Math.min(parseInt(offsetFromPercent(percentFromOffset(offsetLeft(refs.minPtr) - halfWidth(refs.lowBub) + pointerHalfWidth))), barWidth - width(refs.lowBub)) + 'px');
+
 
                                     if(isDualKnob) {
                                         // dual knob slider
@@ -968,8 +968,7 @@ angular.module('vr.directives.slider', ['ngTouch']).directive('slider',
 
                                             // and re-set the low knob's and bubble's new positions
                                             offset(refs.minPtr, offsetFromPercent(stretchedLowPercent));
-                                            offset(refs.lowBub, offsetFromPercent(percentFromOffset(offsetLeft(refs.minPtr) - halfWidth(refs.lowBub) +
-                                                                                                    pointerHalfWidth)));
+	                                        offset(refs.lowBub, Math.min(parseInt(offsetFromPercent(percentFromOffset(offsetLeft(refs.minPtr) - halfWidth(refs.lowBub) + pointerHalfWidth))), barWidth - width(refs.lowBub)) + 'px');
                                         }
 
                                         if(stretchedHighPercent < rawLowPercent + bufferWidthPercentLow) {


### PR DESCRIPTION
This is about a bug I recently discovered, which becomes apparent when the text hovering above/below the slider-knob (the 'low bubble', to be exact) is relatively long. When the slider knob is in the center, the bubble is centered on the knob. When the knob is in its left-most position, the bubble nicely aligns with the left side of the slider. But this is not done for the right-most position. The bubble will remain centered and stick out to the right.

![angular-slider-bubble-sticks-out](https://cloud.githubusercontent.com/assets/4012816/3233152/32213f40-f0bb-11e3-95c2-67d29ce8d62f.png)

The attached pull request fixes this, but probably not very elegantly. When the original developer reads this, they will probably know a nicer way to fix the bug, more in line with the rest of the code.

![angular-slider-bubble-aligns](https://cloud.githubusercontent.com/assets/4012816/3233153/345bd432-f0bb-11e3-94fb-f1a00f082c13.png)
